### PR TITLE
Refactor script loading to main entry

### DIFF
--- a/bericht.html
+++ b/bericht.html
@@ -47,9 +47,6 @@
     <img id="spielBild" alt="Spiel Bild" class="hidden center-block"/>
     <a id="downloadLink" class="hidden centered spaced">Bild herunterladen</a>
 
-   <script type="module">
-import { API_URL } from "./config.js";
-import "./js/app.js";
-</script>
+   <script type="module" src="js/main.js"></script>
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,7 +1,6 @@
-import { API_URL } from "../config.js";
 let uploadedImageUrl = null;
 
-$(document).ready(function() {
+export function initApp(API_URL) {
     // Spiele laden, wenn ein Datum ausgewählt wird
     $('#spieleLaden').on('click', function() {
         const selectedDate = $('#datumAuswahl').val();
@@ -59,8 +58,9 @@ $(document).ready(function() {
             alert("Bitte mindestens ein Spiel auswählen.");
         }
     });
-});
-				 function preloadLogos(logos, callback) {
+}
+
+export function preloadLogos(logos, callback) {
     let loadedCount = 0;
     const images = [];
     logos.forEach(function(logoSrc, index) {
@@ -81,7 +81,7 @@ $(document).ready(function() {
         };
     });
 }
-function generateImage(selectedGames, modus) {
+export function generateImage(selectedGames, modus) {
     const canvas = document.createElement('canvas');
     canvas.width = 1080;
     canvas.height = 1350;

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,7 @@
+import { API_URL } from '../config.js';
+import { initApp } from './app.js';
+
+$(document).ready(function () {
+  initApp(API_URL);
+});
+

--- a/vorschau.html
+++ b/vorschau.html
@@ -57,9 +57,6 @@
     </div>
     <img id="spielBild" alt="Spiel Bild" class="hidden center-block"/>
 
-    <script type="module">
-import { API_URL } from "./config.js";
-import "./js/app.js";
-</script>
+    <script type="module" src="js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add central `main.js` that imports config and initializes app module
- convert `app.js` into exported functions and remove direct config import
- update HTML files to load the new main script instead of inline modules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acc175dd8c83309b1f03f1fab96a7a