### PR TITLE
Modularize Spielberichte JS modules

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -1,0 +1,9 @@
+import { API_URL } from '../config.js';
+
+export async function fetchGames(date) {
+    const response = await fetch(API_URL);
+    const data = await response.json();
+    const filteredData = data.filter(spiel => spiel.gameDateTime && spiel.gameDateTime.startsWith(date));
+    filteredData.sort((a, b) => new Date(a.gameDateTime) - new Date(b.gameDateTime));
+    return filteredData;
+}

--- a/js/imageGenerator.js
+++ b/js/imageGenerator.js
@@ -1,66 +1,4 @@
-let uploadedImageUrl = null;
-
-export function initApp(API_URL) {
-    // Spiele laden, wenn ein Datum ausgewählt wird
-    $('#spieleLaden').on('click', function() {
-        const selectedDate = $('#datumAuswahl').val();
-        if (selectedDate) {
-            $.getJSON(API_URL, function(data) {
-                $('#spieleTabelle tbody').empty();
-                const filteredData = data.filter(function(spiel) {
-                    return spiel.gameDateTime && spiel.gameDateTime.startsWith(selectedDate);
-                });
-                if (filteredData.length > 0) {
-                    filteredData.sort(function(a, b) {
-                    return new Date(a.gameDateTime) - new Date(b.gameDateTime);
-                });
-                filteredData.forEach(function(spiel, index) {
-                        const spielRow = `<tr>
-                            <td>${new Date(spiel.gameDateTime).toLocaleTimeString('de-DE', {hour: '2-digit', minute:'2-digit'})}</td>
-                            <td contenteditable="true">${spiel.venue}</td>
-                            <td contenteditable="true">${spiel.teamAName}</td>
-                            <td contenteditable="true">${spiel.teamBName}</td>
-                            <td contenteditable="true">${spiel.leagueShort}</td>
-                            <td><input type="checkbox" class="spielAuswahl" value="${index}"></td>
-                        </tr>`;
-                        $('#spieleTabelle tbody').append(spielRow);
-                    });
-                } else {
-                    alert("Keine Spiele für das ausgewählte Datum gefunden.");
-                }
-            }).fail(function() {
-                alert("Fehler beim Abrufen der Spieldaten.");
-            });
-        } else {
-            alert("Bitte ein Datum auswählen.");
-        }
-    });
-
-    // Hintergrundbild hochladen
-    $('#hintergrundHochladen').on('change', function(event) {
-        const file = event.target.files[0];
-        if (file) {
-            const reader = new FileReader();
-            reader.onload = function(e) {
-                uploadedImageUrl = e.target.result;
-            };
-            reader.readAsDataURL(file);
-        }
-    });
-
-    // Bild generieren, wenn der Button gedrückt wird
-    $('#bildGenerieren').on('click', function() {
-        const modus = $('#modusAuswahl').val();
-        const selectedGames = modus === 'turnier' ? $('#spieleTabelle tbody tr') : $('.spielAuswahl:checked').closest('tr');
-        if (selectedGames.length > 0) {
-            generateImage(selectedGames, modus);
-        } else {
-            alert("Bitte mindestens ein Spiel auswählen.");
-        }
-    });
-}
-
-export function preloadLogos(logos, callback) {
+function preloadLogos(logos, callback) {
     let loadedCount = 0;
     const images = [];
     logos.forEach(function(logoSrc, index) {
@@ -81,7 +19,7 @@ export function preloadLogos(logos, callback) {
         };
     });
 }
-export function generateImage(selectedGames, modus) {
+export function generateImage(selectedGames, modus, uploadedImageUrl) {
     const canvas = document.createElement('canvas');
     canvas.width = 1080;
     canvas.height = 1350;

--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,7 @@
-import { API_URL } from '../config.js';
-import { initApp } from './app.js';
+import { fetchGames } from './api.js';
+import { initUI } from './ui.js';
+import { generateImage } from './imageGenerator.js';
 
 $(document).ready(function () {
-  initApp(API_URL);
+  initUI(fetchGames, generateImage);
 });
-

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,53 @@
+export function initUI(fetchGames, generateImage) {
+    let uploadedImageUrl = null;
+
+    $('#spieleLaden').on('click', async function() {
+        const selectedDate = $('#datumAuswahl').val();
+        if (selectedDate) {
+            try {
+                const games = await fetchGames(selectedDate);
+                renderGamesTable(games);
+            } catch (error) {
+                alert("Fehler beim Abrufen der Spieldaten.");
+            }
+        } else {
+            alert("Bitte ein Datum auswählen.");
+        }
+    });
+
+    $('#hintergrundHochladen').on('change', function(event) {
+        const file = event.target.files[0];
+        if (file) {
+            const reader = new FileReader();
+            reader.onload = function(e) {
+                uploadedImageUrl = e.target.result;
+            };
+            reader.readAsDataURL(file);
+        }
+    });
+
+    $('#bildGenerieren').on('click', function() {
+        const modus = $('#modusAuswahl').val();
+        const selectedGames = modus === 'turnier' ? $('#spieleTabelle tbody tr') : $('.spielAuswahl:checked').closest('tr');
+        if (selectedGames.length > 0) {
+            generateImage(selectedGames, modus, uploadedImageUrl);
+        } else {
+            alert("Bitte mindestens ein Spiel auswählen.");
+        }
+    });
+}
+
+function renderGamesTable(games) {
+    $('#spieleTabelle tbody').empty();
+    games.forEach(function(spiel, index) {
+        const spielRow = `<tr>
+            <td>${new Date(spiel.gameDateTime).toLocaleTimeString('de-DE', {hour: '2-digit', minute:'2-digit'})}</td>
+            <td contenteditable="true">${spiel.venue}</td>
+            <td contenteditable="true">${spiel.teamAName}</td>
+            <td contenteditable="true">${spiel.teamBName}</td>
+            <td contenteditable="true">${spiel.leagueShort}</td>
+            <td><input type="checkbox" class="spielAuswahl" value="${index}"></td>
+        </tr>`;
+        $('#spieleTabelle tbody').append(spielRow);
+    });
+}


### PR DESCRIPTION
## Summary
- Move game data fetching into new `fetchGames` API module
- Extract UI interactions to `initUI` for table rendering and event setup
- Keep canvas rendering in `generateImage` within `imageGenerator`
- Update `main.js` to wire API, UI, and image generation modules

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68acc2b805bc8330bb8c9828bd17f38a