### PR TITLE
Refactor app initialization into modules

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,9 @@
+import { fetchGames } from './api.js';
+import { initUI } from './ui.js';
+import { generateImage } from './imageGenerator.js';
+
+export function startApp() {
+  $(document).ready(function () {
+    initUI(fetchGames, generateImage);
+  });
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,4 @@
-import { fetchGames } from './api.js';
-import { initUI } from './ui.js';
-import { generateImage } from './imageGenerator.js';
+import { API_URL } from '../config.js';
+import { startApp } from './app.js';
 
-$(document).ready(function () {
-  initUI(fetchGames, generateImage);
-});
+startApp();


### PR DESCRIPTION
## Summary
- create `app.js` exporting `startApp` to initialize the UI
- simplify `main.js` to import config and app modules and call `startApp`

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad59217bd083308487bf2654d95356