### PR TITLE
Refactor HTML pages to use base template

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+const path = require('path');
+
+function render(template, data) {
+  return template.replace(/{{\s*(\w+)\s*}}/g, (_, key) => data[key] || '');
+}
+
+const templatePath = path.join(__dirname, 'templates', 'base.html');
+const baseTemplate = fs.readFileSync(templatePath, 'utf8');
+
+const pages = [
+  {
+    output: 'vorschau.html',
+    data: {
+      title: 'Spiel Daten Visualisierung',
+      header: 'Spieldaten Auswahl',
+      subtitle: 'Wählen Sie ein Datum aus und laden Sie die verfügbaren Spiele',
+      content: `
+    <div class="centered spaced">
+        <label for="datumAuswahl">Datum auswählen:</label>
+        <input type="date" id="datumAuswahl">
+        <button id="spieleLaden">Spiele laden</button>
+    </div>
+    <div class="centered spaced">
+        <label for="titelEingabe">Titel des generierten Bildes:</label>
+        <input type="text" id="titelEingabe" placeholder="Heimspiele">
+    </div>
+    <div class="centered spaced">
+        <label for="hintergrundHochladen">Hintergrundbild hochladen:</label>
+        <input type="file" id="hintergrundHochladen" accept="image/*">
+    </div>
+    <div class="centered spaced">
+        <label for="modusAuswahl">Modus auswählen:</label>
+        <select id="modusAuswahl">
+            <option value="normal">Normalmodus</option>
+            <option value="turnier">Turniermodus</option>
+        </select>
+    </div>`,
+      tableId: 'spieleTabelle',
+      selectionHeader: 'Auswahl',
+      footer: `
+    <div class="centered spaced">
+        <button id="bildGenerieren">Bild generieren</button>
+    </div>
+    <img id="spielBild" alt="Spiel Bild" class="hidden center-block"/>`,
+      scriptPath: 'js/main.js'
+    }
+  },
+  {
+    output: 'bericht.html',
+    data: {
+      title: 'Spiel Daten Visualisierung',
+      header: 'Spielbericht Auswahl',
+      subtitle: 'Wählen Sie ein Datum aus und laden Sie die verfügbaren Spiele',
+      content: `
+    <div class="centered spaced">
+        <label for="datumAuswahl">Datum auswählen:</label>
+        <input type="date" id="datumAuswahl">
+    </div>`,
+      tableId: 'spieleTabelle',
+      selectionHeader: 'Auswahl',
+      footer: '',
+      scriptPath: 'js/main.js'
+    }
+  }
+];
+
+pages.forEach(page => {
+  const output = render(baseTemplate, page.data);
+  fs.writeFileSync(path.join(__dirname, page.output), output);
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Spiel Daten Visualisierung</title>
+    <title>{{title}}</title>
     <script src="https://cdn.jsdelivr.net/npm/context-filter-polyfill/dist/index.min.js"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Ruda:wght@900&display=swap" rel="stylesheet">
@@ -11,19 +11,15 @@
 </head>
 <body>
     <div class="header">
-        <h1>Spielbericht Auswahl</h1>
-        <p>Wählen Sie ein Datum aus und laden Sie die verfügbaren Spiele</p>
+        <h1>{{header}}</h1>
+        <p>{{subtitle}}</p>
     </div>
 
-    
-    <div class="centered spaced">
-        <label for="datumAuswahl">Datum auswählen:</label>
-        <input type="date" id="datumAuswahl">
-    </div>
+    {{content}}
 
     <div id="spieleContainer">
         <h2 class="centered">Verfügbare Spiele</h2>
-        <table id="spieleTabelle" class="schedule-table">
+        <table id="{{tableId}}" class="schedule-table">
             <thead>
                 <tr>
                     <th>Zeit</th>
@@ -31,7 +27,7 @@
                     <th>Team A</th>
                     <th>Team B</th>
                     <th>Liga</th>
-                    <th>Auswahl</th>
+                    <th>{{selectionHeader}}</th>
                 </tr>
             </thead>
             <tbody>
@@ -39,8 +35,8 @@
         </table>
     </div>
 
-    
+    {{footer}}
 
-    <script type="module" src="js/main.js"></script>
+    <script type="module" src="{{scriptPath}}"></script>
 </body>
 </html>

--- a/vorschau.html
+++ b/vorschau.html
@@ -8,13 +8,14 @@
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Ruda:wght@900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/main.css">
-    
 </head>
 <body>
     <div class="header">
         <h1>Spieldaten Auswahl</h1>
         <p>Wählen Sie ein Datum aus und laden Sie die verfügbaren Spiele</p>
     </div>
+
+    
     <div class="centered spaced">
         <label for="datumAuswahl">Datum auswählen:</label>
         <input type="date" id="datumAuswahl">
@@ -35,6 +36,7 @@
             <option value="turnier">Turniermodus</option>
         </select>
     </div>
+
     <div id="spieleContainer">
         <h2 class="centered">Verfügbare Spiele</h2>
         <table id="spieleTabelle" class="schedule-table">
@@ -52,6 +54,8 @@
             </tbody>
         </table>
     </div>
+
+    
     <div class="centered spaced">
         <button id="bildGenerieren">Bild generieren</button>
     </div>


### PR DESCRIPTION
## Summary
- Extract shared head, header, footer and table scaffold into `templates/base.html`
- Add simple `build.js` renderer to generate `vorschau.html` and `bericht.html`
- Regenerate `vorschau.html` and `bericht.html` from the template

## Testing
- `node build.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad5e28522c83309e2645f01a8e9c29