### PR TITLE
Add navigation for preview and report pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+_site/
+.jekyll-cache/
+.sass-cache/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "jekyll"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,161 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.3.0)
+    bigdecimal (3.2.2)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.5)
+    csv (3.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux-musl)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.32.0)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-x86-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-x86-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.0-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    http_parser.rb (0.8.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.4.1)
+      addressable (~> 2.4)
+      base64 (~> 0.2)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3, >= 0.3.6)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.13.2)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (6.0.2)
+    rake (13.3.0)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.2)
+    rouge (4.6.0)
+    safe_yaml (1.0.5)
+    sass-embedded (1.91.0)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.91.0-aarch64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.91.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.91.0-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.91.0-arm-linux-androideabi)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.91.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.91.0-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.91.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.91.0-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.91.0-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.91.0-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.91.0-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.91.0-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.91.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.91.0-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.1)
+
+PLATFORMS
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  jekyll
+
+BUNDLED WITH
+   2.6.7

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+title: Spielberichte Tool

--- a/_includes/bericht.html
+++ b/_includes/bericht.html
@@ -1,0 +1,29 @@
+<section id="bericht">
+    <div class="header">
+        <h1>Spielbericht Auswahl</h1>
+        <p>Wählen Sie ein Datum aus und laden Sie die verfügbaren Spiele</p>
+    </div>
+
+    <div class="centered spaced">
+        <label for="datumAuswahl">Datum auswählen:</label>
+        <input type="date" id="datumAuswahl">
+    </div>
+
+    <div id="spieleContainer">
+        <h2 class="centered">Verfügbare Spiele</h2>
+        <table id="spieleTabelle" class="schedule-table">
+            <thead>
+                <tr>
+                    <th>Zeit</th>
+                    <th>Ort</th>
+                    <th>Team A</th>
+                    <th>Team B</th>
+                    <th>Liga</th>
+                    <th>Auswahl</th>
+                </tr>
+            </thead>
+            <tbody>
+            </tbody>
+        </table>
+    </div>
+</section>

--- a/_includes/vorschau.html
+++ b/_includes/vorschau.html
@@ -1,20 +1,9 @@
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Spiel Daten Visualisierung</title>
-    <script src="https://cdn.jsdelivr.net/npm/context-filter-polyfill/dist/index.min.js"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Ruda:wght@900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="css/main.css">
-</head>
-<body>
+<section id="vorschau">
     <div class="header">
         <h1>Spieldaten Auswahl</h1>
         <p>Wählen Sie ein Datum aus und laden Sie die verfügbaren Spiele</p>
     </div>
 
-    
     <div class="centered spaced">
         <label for="datumAuswahl">Datum auswählen:</label>
         <input type="date" id="datumAuswahl">
@@ -54,12 +43,8 @@
         </table>
     </div>
 
-    
     <div class="centered spaced">
         <button id="bildGenerieren">Bild generieren</button>
     </div>
     <img id="spielBild" alt="Spiel Bild" class="hidden center-block"/>
-
-    <script type="module" src="js/main.js"></script>
-</body>
-</html>
+</section>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ page.title | default: site.title }}</title>
+  <script src="https://cdn.jsdelivr.net/npm/context-filter-polyfill/dist/index.min.js"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Ruda:wght@900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/main.css">
+</head>
+<body>
+  <nav>
+    <ul>
+      <li><a href="{{ '/' | relative_url }}">Vorschau</a></li>
+      <li><a href="{{ '/bericht.html' | relative_url }}">Bericht</a></li>
+    </ul>
+  </nav>
+  {{ content }}
+  <script type="module" src="js/main.js"></script>
+</body>
+</html>

--- a/bericht.html
+++ b/bericht.html
@@ -1,45 +1,6 @@
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Spiel Daten Visualisierung</title>
-    <script src="https://cdn.jsdelivr.net/npm/context-filter-polyfill/dist/index.min.js"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Ruda:wght@900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="css/main.css">
-</head>
-<body>
-    <div class="header">
-        <h1>Spielbericht Auswahl</h1>
-        <p>Wählen Sie ein Datum aus und laden Sie die verfügbaren Spiele</p>
-    </div>
+---
+layout: default
+title: Spielbericht
+---
 
-    
-    <div class="centered spaced">
-        <label for="datumAuswahl">Datum auswählen:</label>
-        <input type="date" id="datumAuswahl">
-    </div>
-
-    <div id="spieleContainer">
-        <h2 class="centered">Verfügbare Spiele</h2>
-        <table id="spieleTabelle" class="schedule-table">
-            <thead>
-                <tr>
-                    <th>Zeit</th>
-                    <th>Ort</th>
-                    <th>Team A</th>
-                    <th>Team B</th>
-                    <th>Liga</th>
-                    <th>Auswahl</th>
-                </tr>
-            </thead>
-            <tbody>
-            </tbody>
-        </table>
-    </div>
-
-    
-
-    <script type="module" src="js/main.js"></script>
-</body>
-</html>
+{% include bericht.html %}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Spielberichte Tool
+---
+
+{% include vorschau.html %}

--- a/js/main.js
+++ b/js/main.js
@@ -3,5 +3,7 @@ import { initUI } from './ui.js';
 import { generateImage } from './imageGenerator.js';
 
 document.addEventListener('DOMContentLoaded', () => {
-    initUI(fetchGames, generateImage);
+    if (document.querySelector('#vorschau')) {
+        initUI(fetchGames, generateImage);
+    }
 });


### PR DESCRIPTION
## Summary
- Render preview on home page and serve report from dedicated page
- Provide layout navigation links for switching between apps
- Load preview scripts only when the preview section is present

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68adcdf2d1f88330bbb79cfe76b12546